### PR TITLE
fix(Callout): Callout strong tag now has proper contrast

### DIFF
--- a/src/components/Callout.jsx
+++ b/src/components/Callout.jsx
@@ -7,7 +7,7 @@ const styles = {
     container:
       'bg-sky-50 dark:bg-slate-800/60 dark:ring-1 dark:ring-slate-300/10',
     title: 'text-sky-900 dark:text-sky-400',
-    body: 'text-sky-800 [--tw-prose-background:theme(colors.sky.50)] prose-a:text-sky-900 prose-code:text-sky-900 dark:text-slate-300 dark:prose-code:text-slate-300',
+    body: 'text-sky-800 [--tw-prose-background:theme(colors.sky.50)] prose-a:text-sky-900 prose-code:text-sky-900 dark:text-slate-300 dark:prose-code:text-slate-300 dark:prose-strong:text-white',
   },
   warning: {
     container:


### PR DESCRIPTION
## What was done? 👀

Callout had an issue when dark mode was turned on where the strong tags were still black, preventing users from having a good reading experience.

## Before

![Screenshot 2023-09-29 at 21 47 46](https://github.com/makeplane/docs/assets/30534965/307d168b-38cf-40f7-90ee-4d77de7d44c7)

## After

![Screenshot 2023-09-29 at 21 47 52](https://github.com/makeplane/docs/assets/30534965/a5936a0d-1397-4c2a-b822-4b7788c2c3b9)
