### PR TITLE
[bug]: self-hosting link in index.md not working

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -10,7 +10,7 @@ Plane is a simple, extensible, open source project and product management tool. 
 
 {% quick-link title="Quick Start" icon="installation" href="/quick-start" description="Learn how to use Plane and follow the best practices of taking-off." /%}
 
-{% quick-link title="Self-host Plane" icon="presets" href="/self-hosting" description="Run Plane on your computer or development machine." /%}
+{% quick-link title="Self-host Plane" icon="presets" href="/self-hosting/docker-compose" description="Run Plane on your computer or development machine." /%}
 
 {% quick-link title="Integrations" icon="plugins" href="/integrations/about" description="Extend Plane with third-party plugins and integrations" /%}
 


### PR DESCRIPTION
![docs](https://github.com/makeplane/docs/assets/73858095/6dcc5750-43cd-4c3b-9d3c-d203c94666ee)
fixing the link in "index.md" from "/self-hosting" to "self-hosting/docker-compose" since it does not exist.