### PR TITLE
Fix command numbers in docker-compose.mdx

### DIFF
--- a/self-hosting/methods/docker-compose.mdx
+++ b/self-hosting/methods/docker-compose.mdx
@@ -98,7 +98,7 @@ This will create a folder `plane-app` or `plane-app-preview` (in case of preview
 -   `docker-compose.yaml`
 -   `.env`
 
-Again the `options [1-6]` will be popped up and this time hit `6` to exit.
+Again the `options [1-8]` will be popped up and this time hit `8` to exit.
 
 * * *
 


### PR DESCRIPTION
Fix self hosting docs with correct representation of command numbers.