### PR TITLE
Fix typo

### DIFF
--- a/self-hosting/methods/kubernetes.mdx
+++ b/self-hosting/methods/kubernetes.mdx
@@ -79,7 +79,7 @@ title: Kubernetes
 |---|:---:|:---:|---|
 | planeVersion | stable | Yes |  |
 
-### Postgress DB Setup
+### Postgres DB Setup
 
 | Setting | Default | Required | Description |
 |---|:---:|:---:|---|


### PR DESCRIPTION
`Postgress` -> `Postgres`