### PR TITLE
docs: Update Docker Compose setup menu options from 1-6 to 1-8

### DIFF
--- a/self-hosting/methods/docker-compose.mdx
+++ b/self-hosting/methods/docker-compose.mdx
@@ -98,7 +98,7 @@ This will create a folder `plane-app` or `plane-app-preview` (in case of preview
 -   `docker-compose.yaml`
 -   `.env`
 
-Again the `options [1-6]` will be popped up and this time hit `6` to exit.
+Again the `options [1-8]` will be popped up and this time hit `8` to exit.
 
 * * *
 


### PR DESCRIPTION
### Changes

1. Updated the action options list to include the new "Backup Data" option:
   - Changed "Again the `options [1-6]` will be popped up" to "Again the `options [1-8]` will be popped up"
   - Updated the "Exit" option from 6 to 8 on the end of the same line