### PR TITLE
Typo: mardown is now markdown

### DIFF
--- a/docs/core-concepts/issues.mdx
+++ b/docs/core-concepts/issues.mdx
@@ -3,7 +3,7 @@ title: Issues
 ---
 Inside an issue, you can add as many details as you like to get your work done. Here are five critical things to kick-start:
 
-1.  **Issue description**: An enhanced mardown editor inside issues to write as much detail you want. Attachments can be added and dragged around with a simple click, no need to save anything. Everything is auto-saved for you.
+1.  **Issue description**: An enhanced markdown editor inside issues to write as much detail you want. Attachments can be added and dragged around with a simple click, no need to save anything. Everything is auto-saved for you.
     
 2.  **Issue sub-properties**: We support basic issue properties such as `priority`, `label`, `due date`, and `assignee`. You can create relations between issues: mark them as `blocked` or `blocking`.
     


### PR DESCRIPTION
Signed-off-by: Tim Beermann <tibeer@outlook.de>
