### PR TITLE
Remove Hypermode and added note in Inbox page

### DIFF
--- a/docs/core-concepts/inbox.mdx
+++ b/docs/core-concepts/inbox.mdx
@@ -14,6 +14,11 @@ The Inbox is a space for tracking and managing updates to work items you're conn
 Located in the sidebar on the left, directly below **Home** and **Your Work**, the **Inbox** is easily accessible with a simple click. This provides instant access to your personalized notification feed.
 ![Inbox](https://media.docs.plane.so/inbox/inbox.webp#center)
 
+:::tip[Email notifications]
+All inbox notifications are also sent to your email by default. You can customize your email notification preferences in [Account Settings](/core-concepts/account/settings#notifications).
+
+:::
+
 ## Work item notifications
 
 When you open the Inbox, you’ll see a chronological list of notifications related to work items assigned to you, the ones you’ve created, and the work items you’re subscribed to.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -144,12 +144,13 @@ const sidebars: SidebarsConfig = {
       label: "Integrations",
       items: ["integrations/about", "integrations/github", "integrations/slack", "integrations/gitlab"],
     },
-    {
+   /* {
       type: "category",
       collapsed: false,
       label: "Performance",
       items: ["performance/hyper-mode"],
     },
+    */
     {
       type: "category",
       collapsed: false,


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a tip in the Inbox docs explaining that inbox alerts are also sent via email by default, with a link to manage notification preferences in Account Settings.
  * Updated site navigation by removing the “Performance” section from the tutorial sidebar, simplifying the docs menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->