### PR TITLE
feat: agent discovery (Link headers, markdown negotiation, Content-Signal)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { resolve } from "path";
+import { copyFileSync, mkdirSync, readFileSync, readdirSync, statSync } from "fs";
+import { dirname, join, relative, resolve } from "path";
 import { defineConfig, type HeadConfig } from "vitepress";
 import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 
@@ -49,6 +49,30 @@ export default defineConfig({
   title: "Plane",
   description: "Modern project management software",
   cleanUrls: true,
+
+  buildEnd(siteConfig) {
+    // Copy source .md files into dist/ for Accept: text/markdown negotiation.
+    const srcDir = siteConfig.srcDir;
+    const outDir = siteConfig.outDir;
+
+    function walk(dir: string): void {
+      for (const entry of readdirSync(dir)) {
+        if (entry === ".vitepress" || entry === "public" || entry === "node_modules") continue;
+        const abs = join(dir, entry);
+        const stat = statSync(abs);
+        if (stat.isDirectory()) {
+          walk(abs);
+        } else if (stat.isFile() && abs.endsWith(".md")) {
+          const rel = relative(srcDir, abs);
+          const dest = join(outDir, rel);
+          mkdirSync(dirname(dest), { recursive: true });
+          copyFileSync(abs, dest);
+        }
+      }
+    }
+
+    walk(srcDir);
+  },
 
   head: [
     [

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -6,4 +6,8 @@ Disallow: /core-concepts/issues.html
 Disallow: /core-concepts/projects/run-project
 Disallow: /importers/github-imp
 
+# Content Signals — AI content usage preferences
+# https://contentsignals.org/
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
+
 Sitemap: https://docs.plane.so/sitemap.xml

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,17 @@
 {
   "cleanUrls": true,
   "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</api-reference/introduction>; rel=\"service-doc\"; type=\"text/html\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\""
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/quick-start",
@@ -261,6 +272,13 @@
     {
       "source": "/performance/hyper-mode",
       "destination": "/"
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
+      "destination": "/:path*.md"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `Content-Signal: search=yes, ai-train=yes, ai-input=yes` to `robots.txt`
- Add `Link` response headers on all paths advertising `/api-reference/introduction` (service-doc) and `/sitemap.xml` (sitemap)
- Serve source markdown when `Accept: text/markdown` is sent — static `.md` files copied into `dist` by a VitePress `buildEnd` hook, routed via a Vercel `rewrites` header matcher

### Adaptations vs developer-docs PR

- Dropped the `rel="describedby"` → `/llms.txt` relation (no `llms.txt` in `docs/public/` here). Add in a follow-up once the file exists.
- `rel="service-doc"` points at `/api-reference/introduction`. That path is not local to this site; the existing `/api-reference/:path*` redirect in `vercel.json` sends agents to `developers.plane.so`.

## Test plan
- [x] `pnpm check:format` passes
- [x] `pnpm build` succeeds and produces 106 `.md` files alongside `.html` in `dist/`
- [x] `docs/.vitepress/dist/robots.txt` contains the `Content-Signal` line

Preview deploy:
- [ ] `curl -I https://<preview>.vercel.app/` shows a `Link:` header with `service-doc` and `sitemap` relations
- [ ] Default `curl https://<preview>.vercel.app/` still returns HTML (regression check)
- [ ] `curl -H "Accept: text/markdown" https://<preview>.vercel.app/introduction/quickstart` returns the markdown body — if returned as `text/plain`, add an explicit `Content-Type: text/markdown; charset=utf-8` header override in a follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search engine optimization signals for improved indexing and AI training preferences
  * Included API documentation links in response headers
  * Enabled markdown content-type negotiation for API requests

* **Chores**
  * Optimized build pipeline for documentation handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->