### PR TITLE
docs: update Plane AI credits page to seat-based model and workspace overage

### DIFF
--- a/docs/ai/plane-ai-credits.md
+++ b/docs/ai/plane-ai-credits.md
@@ -1,154 +1,72 @@
 ---
-title: How AI credits work for team usage and billing
-description: Learn how Plane AI's credit system works, why different tasks consume different amounts, and how workspace pooling helps teams manage AI usage efficiently.
+title: How Plane AI credits work
+description: Understand seat-based AI credits, what happens when included credits run out, and how workspace overage keeps your team moving.
 ---
 
 # Plane AI credits
 
-Plane AI uses credits as a universal measure of AI processing. This system ensures fair usage while giving teams predictable costs and transparent billing.
+Plane AI credits measure AI usage in Plane Cloud.
 
 ::: warning IMPORTANT
 AI credits apply only to Plane Cloud.
 
-On self-hosted instances, you use your own AI provider [API key](https://developers.plane.so/self-hosting/govern/instance-admin#artificial-intelligence), and all AI usage and costs are managed directly through your provider. Plane does not track, pool, or enforce usage through credits.
+On self-hosted instances, you use your own AI provider [API key](https://developers.plane.so/self-hosting/govern/instance-admin#artificial-intelligence), and all AI usage and costs are managed directly through your provider.
 :::
 
-## Why credits instead of limits?
+## How credits are assigned
 
-Traditional AI tools often impose hard limits, like "10 queries per day" or "50 messages per month." These limits create frustration because not all AI tasks are equal. A quick status check shouldn't cost the same as generating a full project plan.
+Credits are included **per paid seat**.
 
-Credits solve this by measuring actual computational work. Simple tasks consume fewer credits. Complex tasks consume more. This means you pay for what you use, not arbitrary quotas.
+- Each active seat gets a monthly included credit amount based on your plan.
+- Included credits are account-level entitlements tied to seats.
+- This model is designed to be simple and predictable, similar to how modern AI products commonly package usage.
 
-## What determines credit consumption?
+For current included amounts by plan, check the latest pricing details on [Plane pricing](https://plane.so/pricing#ai-&-credits).
 
-Three factors influence how many credits a task consumes:
+## No default pooling
 
-**Task complexity** measures the reasoning required. A straightforward question like "What's the status of work item SOFTW-124?" requires minimal processing. A request like "Analyze our project structure and suggest optimizations" requires multi-step reasoning, context synthesis, and detailed analysis.
+Plane AI credits are **not pooled by default**.
 
-**Response length** affects consumption because longer outputs require more generation. A brief answer might be 50 words. A detailed report with code examples might be 2,000 words. The AI needs to generate, validate, and format every word.
+That means one member's unused included credits are not automatically shared across the rest of the workspace.
 
-**Action scope** determines whether the AI is reading information or modifying your workspace. Querying existing data is lightweight. Creating 20 work items, each with descriptions, assignees, and metadata, requires multiple write operations and validations.
+## What happens when included credits run out
 
-## Credit consumption patterns
+If a member (or your workspace's included capacity) runs out of available credits for the billing period, AI usage can stop unless overage is enabled.
 
-Here's how these factors translate into typical usage:
+Workspace admins can enable a workspace-level overage setting so teams can continue using AI after included credits are exhausted.
 
-| Action type      | Credit range | What this looks like                                                   |
-| ---------------- | ------------ | ---------------------------------------------------------------------- |
-| **Short query**  | ~10 credits  | Quick questions, status checks, brief clarifications                   |
-| **Long query**   | ~50 credits  | Detailed explanations, code generation, analytical responses           |
-| **Action**       | ~100 credits | Creating or editing multiple work items, generating project structures |
-| **Heavy action** | ~250 credits | Bulk operations, file analysis, complex workflow automation            |
+## Workspace overage
 
-To illustrate with a real workflow:
+When workspace overage is enabled:
 
-| Task                                                     | Why this credit amount                                       |
-| -------------------------------------------------------- | ------------------------------------------------------------ |
-| Summarize yesterday's stand-up notes (10 credits)        | Simple extraction and formatting of existing text            |
-| Generate detailed project timeline (50 credits)          | Requires analysis, structure creation, and detailed output   |
-| Create 20 tasks from PRD (100 credits)                   | Multiple write operations with metadata for each work item   |
-| Analyze project structure for optimization (250 credits) | Deep analysis across multiple projects, with recommendations |
+- AI usage continues after included credits are consumed.
+- Additional usage is billed at the workspace level.
+- Admins stay in control of whether overage is allowed.
 
-With 10,000 credits, you could handle approximately:
+If overage is disabled, new AI actions are paused after included credits are exhausted until credits reset or additional capacity is purchased/enabled.
 
-- 1000 short queries, or
-- 200 long queries, or
-- 100 actions, or
-- 40 heavy actions, or
-- any mix that fits your workflow.
+## Tracking and controls
 
-## Plan comparison
+Plane provides usage visibility so admins can manage cost and adoption:
 
-| Plan           | Monthly credits per user | Rollover period |
-| -------------- | ------------------------ | --------------- |
-| **Free**       | 500                      | No rollover     |
-| **Pro**        | 1,000                    | 1 month         |
-| **Business**   | 2,000                    | 3 months        |
-| **Enterprise** | Flexible allocation      | Up to 12 months |
-
-New workspaces receive 1,000 bonus credits upon signup. These onboarding credits expire after 30 days and help teams evaluate Plane AI before committing to a plan.
-
-## How workspace pooling works
-
-Credits are allocated at the workspace level, not per individual. This creates a shared pool that all members draw from.
-
-This approach exists because teams don't use AI uniformly. Some members might use AI heavily during cycle planning, others during code reviews, others barely at all. A per-user allocation would mean unused credits in some accounts while others run dry.
-
-Here's how it works in practice:
-
-A team of 20 users on the Pro Plan receives 20 × 1,000 = 20,000 credits per month for their workspace. All 20 members use this shared pool. When someone creates 5 work items with AI (consuming ~50 credits), that deduction comes from the workspace balance, not an individual quota.
-
-Admins can monitor usage patterns, set per-user limits if needed, and see which activities consume the most credits. This visibility helps teams optimize their AI usage over time.
-
-## Credit lifecycle and rollover
-
-Different plans handle credit expiration differently, reflecting how teams use AI over time:
-
-**Free plan** credits don't roll over. The 500 monthly credits reset each month.
-
-**Pro plan** credits roll over for 1 month. This accommodates the reality that usage fluctuates—one month might be heavy on planning, the next on execution. The rollover prevents "use it or lose it" pressure.
-
-**Business plan** credits roll over for 3 months, recognizing that larger teams have more variable usage patterns. Seasonal projects, team changes, and workflow shifts mean monthly consumption varies significantly.
-
-**Enterprise plan** credits can roll over up to 12 months, providing maximum flexibility for organizations with complex, long-term projects.
-
-When you have credits from multiple sources (monthly allocation + rollover + top-ups), the system always uses the oldest credits first. This prevents newer credits from expiring while older ones sit unused.
-
-## Top-up credits
-
-Top-ups exist for months when your team's usage exceeds the plan allocation. These are one-time purchases that don't auto-renew.
-
-| Pack size     | Credits | Price (USD) | Best for                                  |
-| ------------- | ------- | ----------- | ----------------------------------------- |
-| Standard pack | 1,000   | $2.00       | Light monthly overages                    |
-| Growth pack   | 2,000   | $4.00       | Small active teams                        |
-| Scale pack    | 5,000   | $9.00       | Moderate automation use                   |
-| Bulk pack     | 10,000  | $17.00      | Larger workspaces (best value per credit) |
-
-Top-up credits are added instantly to your workspace's shared balance and expire 12 months after purchase. All workspace members can use them, and admins can track consumption in the usage dashboard.
-
-## What doesn't consume credits
-
-Viewing AI-generated results never costs credits. Once the AI creates something, you can revisit it unlimited times at no cost.
-
-Managing your AI history, reviewing past conversations, editing saved prompts, organizing results is free. Storage doesn't consume credits.
-
-Deleting AI-generated content doesn't recover credits. The computational work already happened, so removing the output doesn't reverse the consumption.
-
-## Fair usage and transparency
-
-Every action shows its estimated credit cost before execution. This preview lets you decide whether the task is worth the consumption.
-
-If a task fails due to technical issues on Plane's side, those credits are refunded automatically. You only pay for successful AI operations.
-
-The usage dashboard shows your remaining balance, consumption history, and per-action breakdowns in real time. Admins can download detailed reports for capacity planning and budget forecasting.
-
-Alerts notify workspace admins when the balance reaches 20% and 5% of total capacity, providing time to top up or adjust usage patterns.
+- Current credit balance and consumption trends
+- Workspace-level usage monitoring
+- Billing visibility for additional usage when overage is enabled
 
 ## FAQs
 
-::: details Why this pricing model?
-Credits provide granular control while remaining predictable. Unlike token-based pricing (which fluctuates based on AI model costs), credits give you stable rates. Unlike subscription tiers with arbitrary limits, credits scale naturally with your actual usage.
+::: details Are credits shared automatically across all users in my workspace?
+No. Plane does not use automatic credit pooling by default.
 :::
 
-::: details How long do credits last?
-It depends on your plan and how you acquired them. Free plan credits reset monthly with no rollover. Pro plan credits roll over for 1 month, Business for 3 months, and Enterprise plans roll over for up to 12 months. Top-up credits purchased separately are valid for 12 months on all paid plans, regardless of your base plan's rollover period.
+::: details Do I get credits for each seat?
+Yes. Included credits are assigned per paid seat based on your plan.
 :::
 
-::: details Do all workspace members share the same credit pool?
-Yes. Credits are allocated at the workspace level, creating a shared balance that all members draw from. This prevents the problem of some team members having unused credits while others run out. Admins can set per-user limits if needed to prevent any single member from consuming the entire pool.
+::: details Can we keep using AI after included credits are used up?
+Yes, if a workspace admin enables overage at the workspace level.
 :::
 
-::: details What happens when my workspace runs out of credits?
-You'll receive alerts when your balance reaches 20% and 5% of total capacity, giving you time to respond. Once you hit zero, AI features become unavailable until you top up or your monthly allocation renews. Your existing data, past AI results, and all non-AI functionality remain fully accessible. You just can't request new AI operations.
+::: details Where can I see the latest included credit amounts?
+Visit [Plane pricing](https://plane.so/pricing#ai-&-credits) for the most up-to-date plan details.
 :::
-
-::: details Can I switch between plans without losing credits?
-Yes, you can change plans anytime. When you switch, your unused credits carry forward and adopt the new plan's rollover rules. If you upgrade mid-month, your increased allocation takes effect immediately. If you downgrade, the change happens at your next billing cycle to avoid losing paid credits.
-:::
-
-::: details How can I monitor my workspace's credit usage?
-The real-time dashboard shows your remaining balance, consumption history, and trends over time. Before executing any AI action, you'll see a credit cost preview.
-:::
-
-Ready to explore how Plane AI can help your team? [View our pricing options](https://plane.so/pricing#ai-&-credits) or start with 1,000 free credits.


### PR DESCRIPTION
### Motivation

- Align the docs with the new billing model where credits are included per paid seat rather than pooled by default.
- Clarify behavior when included credits run out and how workspace-level overage works so admins can choose to continue AI usage.
- Remove outdated or prescriptive pricing/rollover/top-up content that no longer reflects product behavior and could confuse customers.

### Description

- Rewrote `docs/ai/plane-ai-credits.md` to explain that credits are assigned per paid seat and to point readers to `https://plane.so/pricing#ai-&-credits` for current included amounts.
- Removed legacy sections covering automatic workspace pooling, detailed plan tables, top-up pack pricing, and complex rollover rules.
- Added a clear section that Plane does not pool credits by default and that workspace admins may enable workspace-level overage to allow continued AI usage after included credits are exhausted.
- Simplified the FAQ to cover seat allocation, pooling behavior, overage, and where to find up-to-date plan details.

### Testing

- Ran `pnpm check:format` in the `docs` repo and the formatting check passed successfully.
- The formatting run emitted a non-blocking Node engine warning but completed with all files correctly formatted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd0260698832ab1739a902c69c27c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI credits documentation with reorganized information about credit allocation per seat, overage configuration, and workspace-level billing mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->