### PR TITLE
Reframe GAC as the granularity layer in roles and permissions docs

### DIFF
--- a/docs/roles-and-permissions/overview.md
+++ b/docs/roles-and-permissions/overview.md
@@ -9,13 +9,15 @@ Plane uses a layered access control system to determine what every user can see 
 
 If you're looking for what a specific role can or can't do, see the [Permissions matrix](/roles-and-permissions/permissions-matrix). If you want a list of system roles, see [Member roles](/roles-and-permissions/member-roles). If you want to perform a task, see the how-to guides linked at the bottom of this page.
 
-## How GAC and RBAC fit together
+## Essential differences between RBAC and GAC
 
-Plane's permission system pairs two complementary concepts.
+RBAC is the default inside Plane. GAC lets you define roles with fine-grained permissions.
 
-**Granular Access Control (GAC)** is the catalog of fine-grained permissions — actions like editing a work item, publishing a page, archiving a project, or managing labels. Every action a user takes in Plane is one of these granular permissions.
+**Role-Based Access Control (RBAC)**  
+Every user holds a role—either a system-defined one like Owner, Admin, Member, Guest, Contributor, or Commenter or a [custom one](/roles-and-permissions/custom-roles)—and that role carries a defined set of permissions. All of our plans come with pre-set system-defined roles.
 
-**Role-Based Access Control (RBAC)** is how those permissions get assigned. Every user holds a role — either a system-defined role (Owner, Admin, Member, Guest, Contributor, or Commenter) or a [custom role](/roles-and-permissions/custom-roles) — and the role bundles a defined set of GAC permissions.
+**Granular Access Control (GAC)**  
+GAC unlocks custom roles, each composed of one or more permission schemes. This lets you go beyond system-defined roles to create and control exactly what a role can and cannot do.
 
 :::tip
 Owner, Member, and Guest are available on all plans. Other system-defined roles are exclusive to the Business plan and higher. See [Plan availability](/roles-and-permissions/overview#plan-availability).

--- a/docs/roles-and-permissions/overview.md
+++ b/docs/roles-and-permissions/overview.md
@@ -9,13 +9,13 @@ Plane uses a layered access control system to determine what every user can see 
 
 If you're looking for what a specific role can or can't do, see the [Permissions matrix](/roles-and-permissions/permissions-matrix). If you want a list of system roles, see [Member roles](/roles-and-permissions/member-roles). If you want to perform a task, see the how-to guides linked at the bottom of this page.
 
-## Two layers: RBAC and GAC
+## How GAC and RBAC fit together
 
-Plane combines two access control models.
+Plane's permission system pairs two complementary concepts.
 
-**Role-Based Access Control (RBAC)** is the foundation. Every user holds a role — either a system-defined role (Owner, Admin, Member, Guest, Contributor, or Commenter) or a [custom role](/roles-and-permissions/custom-roles) — and that role carries a defined set of permissions.
+**Granular Access Control (GAC)** is the catalog of fine-grained permissions — actions like editing a work item, publishing a page, archiving a project, or managing labels. Every action a user takes in Plane is one of these granular permissions.
 
-**Granular Access Control (GAC)** sits on top. It lets you grant or deny specific permissions to specific users on specific resources, independent of their role. A Contributor could be denied "delete work items" on one particular project while keeping that permission everywhere else, or a specific user could be granted temporary edit access to a single page for the duration of an external review — all without changing anyone's role. GAC is for the exceptions — situations where role-level access is too coarse.
+**Role-Based Access Control (RBAC)** is how those permissions get assigned. Every user holds a role — either a system-defined role (Owner, Admin, Member, Guest, Contributor, or Commenter) or a [custom role](/roles-and-permissions/custom-roles) — and the role bundles a defined set of GAC permissions.
 
 :::tip
 Owner, Member, and Guest are available on all plans. Other system-defined roles are exclusive to the Business plan and higher. See [Plan availability](/roles-and-permissions/overview#plan-availability).
@@ -90,7 +90,7 @@ When a user attempts an action, the system evaluates access in a fixed order, st
 
 A few worked examples make this concrete.
 
-**Can Bob edit work items** Bob has the Contributor role on the project. The system finds no per-resource grant on the issue, walks up to the project, finds Bob's Contributor role, sees that Contributor includes `workitem:edit`, and allows the edit.
+**Can Bob edit work items?** Bob has the Contributor role on the project. The system finds Bob's Contributor role on the project, sees that Contributor includes `workitem:edit`, and allows the edit.
 
 **Can Carol delete modules?** Carol has the Contributor role on the project. Contributor has `module:delete+creator`. The system checks whether Carol created the module — if yes, allowed; if no, denied.
 

--- a/docs/roles-and-permissions/permission-schemes.md
+++ b/docs/roles-and-permissions/permission-schemes.md
@@ -86,7 +86,7 @@ The role's effective permissions become the union of all attached schemes.
 When a role has multiple schemes attached, the effective permission set is the union of all of them. The combination rules are:
 
 - **Unconditional grants win over conditional ones.** If one scheme grants `workitem:delete` and another grants `workitem:delete+creator`, the role gets unconditional `workitem:delete`.
-- **More permissive wins.** If schemes grant the same permission, it's still granted (there's no "negative override" within scheme combinations — that requires GAC).
+- **More permissive wins.** If schemes grant the same permission, it's still granted. Scheme combination is union-only — you cannot subtract permissions by adding another scheme.
 - **Permission dependencies are auto-managed.** Enabling a permission auto-enables its prerequisites (e.g., enabling Edit auto-enables View). Disabling a prerequisite auto-disables permissions that depend on it.
 
 ## See also


### PR DESCRIPTION
## Summary

- Reframes the "Two layers: RBAC and GAC" section of the Roles and permissions overview so that GAC is described as the catalog of fine-grained permissions and RBAC as how those permissions get bundled into roles. The previous framing positioned GAC as an "exceptions layer that sits on top" of RBAC, which doesn't match what's actually shipping (the `permissions_grant`/`permissions_deny` per-user, per-resource override path has no FE wiring today).
- Cleans up a worked example that referenced "no per-resource grant on the issue," which presumed that override path exists in the user-facing product.
- Removes the claim in `permission-schemes.md` that scheme combinations need GAC to express "negative overrides." Scheme combination is union-only.

## Test plan

- [ ] Render the docs locally and read "Roles and permissions" end to end; confirm the new section flows into "What changed from earlier versions" and that the Bob example reads cleanly alongside Carol and Dave.
- [ ] Render "Permission schemes" and confirm the "How permissions combine" list still reads as a coherent set of rules.
- [ ] Verify no internal links broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote access control model documentation for improved clarity, better defining core concepts and how permission assignment works.
  * Clarified permission scheme combination behavior, explaining that multiple schemes combine additively with no negative overrides.
  * Simplified permission evaluation examples throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->