### PR TITLE
docs: add getting-started guide for new users

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -1,0 +1,93 @@
+# Getting Started with Plane
+
+> New to Plane? This guide takes you from zero to a working project in under 10 minutes. No theory — just action.
+>
+> Already familiar with Plane? Head to [Core Concepts](./core-concepts.md) for feature deep-dives or [Tutorials](./tutorials/) for advanced workflows.
+
+## What is Plane? (30-second overview)
+
+Plane is an open source project management tool — a free alternative to Jira or Linear. Here is all the terminology you need:
+
+| Term | What it means |
+|---|---|
+| **Workspace** | Your organisation's home on Plane — everything lives here |
+| **Project** | A specific area of work — e.g. "Website Redesign" |
+| **Work Item** | A single task — e.g. "Fix login bug" |
+| **Cycle** | A time-boxed sprint — a fixed period to complete work |
+| **Module** | A group of related work items — like an epic |
+| **View** | A saved filter — see exactly what you need |
+
+## Before You Begin
+
+You will need:
+- A valid email address
+- A browser (Chrome, Firefox, or Edge recommended)
+
+## Step 1 — Create your Plane account
+
+1. Go to [app.plane.so](https://app.plane.so)
+2. Click **Sign Up** and enter your email address
+3. Check your email for a verification link and click it
+4. Set your name and password
+
+> **Tip:** You can also sign up using your Google or GitHub account for faster access.
+
+## Step 2 — Create your Workspace
+
+1. After signing up you will be prompted to create a workspace
+2. Enter your **Workspace Name** — use your company or team name
+3. Choose your workspace URL
+4. Select your team size
+5. Click **Create Workspace**
+
+> **Tip:** Choose your workspace name carefully — it is visible to all team members you invite.
+
+## Step 3 — Invite your team
+
+1. Click **Settings** in the left sidebar
+2. Click **Members**
+3. Click **Invite Members**
+4. Enter your colleague's email address
+5. Choose their role — Member for most people, Admin for those who need full control
+6. Click **Send Invite**
+
+## Step 4 — Create your first Project
+
+1. Click **Projects** in the left sidebar
+2. Click **Create Project**
+3. Enter your Project Name — be specific (e.g. "Product Roadmap Q2")
+4. Add a description
+5. Choose network — Secret (invited members only) or Public (all workspace members)
+6. Click **Create Project**
+
+## Step 5 — Add your first Work Items
+
+1. Inside your project click **Issues** in the left sidebar
+2. Click **Create Issue**
+3. Write a clear title — e.g. "Design homepage mockup" not just "Design work"
+4. Set a Priority — Urgent, High, Medium, or Low
+5. Assign it to a team member
+6. Set a Due Date if needed
+7. Click **Create Issue**
+
+## Step 6 — Plan your first Cycle
+
+1. Click **Cycles** in the left sidebar
+2. Click **Create Cycle**
+3. Give your Cycle a name — e.g. "Sprint 1 — April"
+4. Set a Start Date and End Date — 1 or 2 weeks is a good starting point
+5. Add work items from your backlog into the Cycle
+6. Click **Create**
+
+## What to Explore Next
+
+| I want to... | Go to... |
+|---|---|
+| Understand all Plane features | Core Concepts |
+| Learn advanced workflows | Tutorials |
+| Set up Plane on my own server | Self-Host Plane |
+| Connect Plane to GitHub or Slack | Integrations |
+
+---
+
+*This guide was contributed by Gori Goyal as part of the Plane Community Documentation Improvement Project (April 2026).*

--- a/docs/introduction/tutorials/overview.md
+++ b/docs/introduction/tutorials/overview.md
@@ -3,6 +3,8 @@ title: Tutorials
 description: Step-by-step guides to master Plane's essential features and build effective team workflows.
 ---
 
+> 💡 **New to Plane?** If you're setting up Plane for the first time, start with the **[Quickstart guide](/introduction/quickstart)** for a step-by-step setup walkthrough. Come back here once you're set up to master advanced features.
+
 # Tutorials
 
 Master Plane's core features with hands-on, step-by-step tutorials designed to get you and your team productive quickly. These tutorials follow a logical progression from workspace setup to advanced collaboration, ensuring you build skills systematically.

--- a/docs/workspaces-and-users/power-k.md
+++ b/docs/workspaces-and-users/power-k.md
@@ -1,0 +1,48 @@
+---
+title: Power K
+description: Use Power K keyboard shortcuts to navigate Plane faster without touching your mouse.
+---
+
+# Power K
+
+Power K is Plane's command palette — a keyboard-driven menu that lets you create, navigate, and manage your workspace without using your mouse. Open it from anywhere in Plane by pressing **Ctrl + K** (Windows/Linux) or **Cmd + K** (Mac).
+
+## Keyboard Shortcuts
+
+### Create
+
+| Action | Shortcut |
+|---|---|
+| New work item | `N` then `I` |
+| New project | `N` then `P` |
+| New dashboard | `N` then `B` |
+
+### Navigate
+
+| Action | Shortcut |
+|---|---|
+| Open a project | `O` then `P` |
+| Open workspace settings | `O` then `S` |
+| Open a workspace | `O` then `W` |
+| Go to home | `G` then `H` |
+| Go to inbox | `G` then `X` |
+| Go to your work | `G` then `Y` |
+| Go to workspace analytics | `G` then `A` |
+| Go to workspace settings | `G` then `S` |
+| Go to workspace drafts | `G` then `J` |
+| Go to workspace archives | `G` then `R` |
+| Go to dashboards | `G` then `B` |
+| Go to projects list | `G` then `P` |
+
+### Miscellaneous
+
+| Action | Shortcut |
+|---|---|
+| Toggle app sidebar | `Ctrl + B` |
+| Copy current page URL | `Ctrl + Shift + C` |
+
+## Tips
+
+- Shortcuts are **sequential** — press the first key, release it, then press the second key. Do not hold both keys simultaneously.
+- Power K also works as a **search bar** — type any page, project, or work item name to navigate directly to it.
+- Use Power K to avoid switching between keyboard and mouse, which speeds up your workflow significantly.


### PR DESCRIPTION
## Description
Added a new `getting-started.md` guide to help new users set up Plane in under 10 minutes. This addresses a navigation gap identified during a full documentation audit — new users naturally navigate to Tutorials first expecting a practical setup guide, but find theory there. The actual step-by-step setup guide is in Quickstart which users assume is just a brief overview.

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## What this PR adds
- Step-by-step account setup guide (6 steps from signup to first Cycle)
- Key terminology table (Workspace, Project, Work Item, Cycle, Module, View)
- Tips and callout boxes for common mistakes
- Navigation table directing users to the right next section

## Why this matters
New users who want to set up Plane practically will instinctively click Tutorials first. This guide provides a clear action-oriented entry point and directs users to the right sections afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Getting Started guide with a 30-second overview and step-by-step onboarding (account, workspace, inviting team, creating a project, adding work items, and planning a cycle), plus a “What to Explore Next” navigation table to other key docs.
  * Added an introductory callout to the Tutorials overview prompting new users to start with the Quickstart guide.
  * Added documentation for the “Power K” command palette, including how to open it and available keyboard shortcuts and tips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->