### PR TITLE
fix: resolve js-yaml DoS vulnerability (Dependabot #67)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   esbuild: ^0.25.0
   vite: 6.4.3
   postcss: ^8.5.10
+  js-yaml@<3.15.0: 3.15.0
 
 importers:
 
@@ -1179,8 +1180,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   kind-of@6.0.3:
@@ -2608,7 +2609,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -2645,7 +2646,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,4 @@ overrides:
   esbuild: ^0.25.0
   vite: 6.4.3
   postcss: ^8.5.10
+  js-yaml@<3.15.0: 3.15.0


### PR DESCRIPTION
## Summary

Resolves the one open Dependabot alert on the repository:

- **[#67] js-yaml — Quadratic-complexity DoS in merge key handling via repeated aliases**
  - Advisory: [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) (CVE-2026-53550), moderate severity
  - Vulnerable range: `< 3.15.0`; patched in `3.15.0`
  - `js-yaml` is a transitive dev dependency pulled in by `gray-matter@4.0.3` (used by VitePress for frontmatter parsing).

## Change

Added a scoped pnpm override in `pnpm-workspace.yaml` that bumps only the vulnerable range:

```yaml
overrides:
  js-yaml@<3.15.0: 3.15.0
```

`gray-matter@4.0.3` accepts `js-yaml@^3.13.1`, so `3.15.0` is fully compatible. The lockfile now resolves `js-yaml` to `3.15.0` everywhere; the vulnerable `3.14.2` is gone.

## Verification

- `pnpm install` — lockfile regenerated, `js-yaml` resolved to `3.15.0`
- `pnpm build` — succeeds
- `pnpm check:format` — passes