### PR TITLE
fix: neutral inline code color and github-dark syntax theme for readability

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -786,7 +786,7 @@ if(n<200&&document.readyState==="loading")requestAnimationFrame(function(){bar(n
   markdown: {
     theme: {
       light: "github-light",
-      dark: "dracula",
+      dark: "github-dark",
     },
     config(md) {
       md.use(tabsMarkdownPlugin);

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -152,6 +152,11 @@ html.dark {
   --vp-c-brand-soft: rgba(0, 99, 153, 0.14);
   --plane-500: #006399;
 
+  /* Inline code — neutral body-text color instead of the VitePress default
+     (brand blue), which is hard to read on the dark pill background.
+     Linked code keeps --vp-code-link-color (brand) so links stay visible. */
+  --vp-code-color: var(--vp-c-text-1);
+
   /* Fonts — Inter for body and headings (override VoidZero APK Protocol) */
   --font-heading: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;


### PR DESCRIPTION
## Problem

Inline code inherits the brand color via VitePress's default `--vp-code-color: var(--vp-c-brand-1)`, so every inline code span renders in Plane blue on a gray pill — hard to read, especially in dark mode. Dark code blocks also used the `dracula` syntax theme, whose palette assumes a `#282a36` background, but our blocks sit on near-black `#0f0f0f`, washing out comments and muted tokens.

Before
<img width="2862" height="1240" alt="CleanShot 2026-07-23 at 20 31 25@2x" src="https://github.com/user-attachments/assets/363e2872-1c5e-49fb-a64a-de8ad6bfa014" />

After
<img width="2866" height="1210" alt="CleanShot 2026-07-23 at 20 30 57@2x" src="https://github.com/user-attachments/assets/a6313874-94c5-41a8-b511-f9338749a338" />


## Changes

- `style.css`: override `--vp-code-color` to `var(--vp-c-text-1)` so inline code uses the neutral body-text color in both modes (GitHub-style — monospace + pill background signal code, not color). Code inside links keeps brand blue via `--vp-code-link-color`.
- `config.ts`: swap the dark syntax theme `dracula` → `github-dark`, designed for dark backgrounds.

## Verification

- Served the production build and checked code-heavy pages (PQL reference, Plane Runner) in both modes: inline code is now high-contrast neutral pills; TypeScript blocks show clearly legible keywords/types/comments; light mode unchanged.
- `pnpm check:format` and `pnpm build` pass.

Companion PR in developer-docs applies the same treatment for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation’s dark theme to GitHub Dark.
  * Improved inline code readability by using neutral text coloring across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->