### PR TITLE
docs: rewrite work item copy section for the unified copy flow

### DIFF
--- a/docs/core-concepts/issues/bulk-ops.md
+++ b/docs/core-concepts/issues/bulk-ops.md
@@ -31,6 +31,19 @@ You can modify several properties across multiple work items simultaneously:
 - Set or modify modules
 - Add or update start and due dates
 
+## Copy work items
+
+Select the work items you want, then choose **Make a copy** from the bulk actions. Pick a destination project — it defaults to the current one — and confirm.
+
+Which properties survive the copy depends on whether the destination is the same project or a different one. See [What gets copied](/core-concepts/issues/overview#what-gets-copied) for the full field-by-field breakdown; bulk copies follow the same rules as copying a single work item.
+
+A few things specific to copying in bulk:
+
+- You can copy up to **1000 work items** at a time.
+- You need permission to create work items in the destination project.
+- The copy runs in the background, so the new work items appear in the destination project shortly after you confirm rather than all at once.
+- If the selection contains epics and the destination project has no Epic type, those epics are skipped and the rest of the selection still copies.
+
 ## Subscribe to multiple work items
 
 If you need to keep track of several work items at once, you can subscribe to multiple work items in a single operation. This ensures you'll receive notifications about any updates to those work items.

--- a/docs/core-concepts/issues/overview.md
+++ b/docs/core-concepts/issues/overview.md
@@ -101,19 +101,44 @@ A work item in Project A can be a sub-work item of a work item in Project B. The
 
 ## Duplicate work items <Badge type="info" text="Pro" />
 
-When you need to create similar work items or replicate a work item's structure and properties, Plane lets you duplicate existing work items either within the same project or across different projects.
+Use **Make a copy** to replicate a work item — either in its own project or in another project in the workspace. It's a quick way to spin up recurring tasks, reuse a well-structured work item as a template, or hand work off to another team.
 
-To duplicate a work item, click the **•••** menu in the work item header and select **Make a copy**. You'll see two options:
+Click the **•••** menu in the work item header and select **Make a copy**. In the modal, pick the destination project — it defaults to the current one — and confirm. The copy always gets a fresh ID from the destination project's sequence.
 
-### Copy in same project
+### What gets copied
 
-Creates an identical work item within the current project with all the same properties, description, and settings. The new work item gets a fresh identifier and maintains the same title, description, state, and priority attributes.
+How much of the original carries over depends on whether you copy in place or into a different project. Labels, modules, cycles, and estimates belong to a single project, so they can't follow a work item across the boundary.
 
-### Copy in different project
+| Property              | Same project     | Different project                   |
+| --------------------- | ---------------- | ----------------------------------- |
+| Title                 | `<title> (Copy)` | Unchanged                           |
+| Work item type        | Retained         | Destination project's default type  |
+| State                 | Retained         | Destination project's default state |
+| Priority              | Retained         | Retained                            |
+| Start and due dates   | Retained         | Retained                            |
+| Description           | Copied           | Copied                              |
+| Links and attachments | Copied           | Copied                              |
+| Assignees             | Retained         | Cleared                             |
+| Labels                | Retained         | Cleared                             |
+| Modules               | Retained         | Cleared                             |
+| Cycle                 | Retained         | Cleared                             |
+| Estimate              | Retained         | Cleared                             |
+| Custom properties     | Retained         | Appended to the description as text |
+| Releases              | Retained         | Retained                            |
+| Sub-work items        | Not copied       | Not copied                          |
+| Customer requests     | Not copied       | Not copied                          |
 
-Duplicates the work item to another project in your workspace. This is particularly useful when you have similar tasks across multiple projects or want to move work items between teams. The copied work item adapts to the destination project's identifier format and default state.
+The copy is also linked back to the original with a **Duplicate of** relation, so you can always trace where it came from.
 
-Duplicating work items is perfect for replicating recurring tasks, or moving work between project phases while maintaining all the essential context and settings.
+::: tip
+Custom property values are project-specific, so they can't be carried into another project's properties. Instead of dropping them, Plane writes them into the bottom of the copied work item's description — nothing is lost, but you'll need to re-enter them against the destination project's own properties if you want them as structured values.
+:::
+
+### Notes and limits
+
+- **Epics** can only be copied into a project that has epics enabled. If the destination project doesn't, the copy is skipped.
+- **Archived work items** are copied as active work items, not as archived ones.
+- Copying multiple work items at once via [bulk operations](/core-concepts/issues/bulk-ops) follows exactly the same rules as copying a single one.
 
 ## Add dependencies
 

--- a/docs/core-concepts/issues/overview.md
+++ b/docs/core-concepts/issues/overview.md
@@ -138,7 +138,7 @@ Custom property values are project-specific, so they can't be carried into anoth
 
 - **Epics** copied into a different project need an Epic type in the destination — that is, the destination project must have [Work item types](/core-concepts/issues/epics) enabled. If it doesn't, Plane refuses the copy with an error instead of demoting the epic to a regular work item. Copying an epic within its own project always works.
 - **Archived work items** are copied as active work items, not as archived ones.
-- Copying multiple work items at once via [bulk operations](/core-concepts/issues/bulk-ops) follows the same field rules as copying a single one. The one difference is the epic case above: in a bulk copy, epics that can't land in the destination are skipped and the rest of the selection still copies.
+- You can copy work items in bulk, too. The field rules above apply there as well — see [Copy work items](/core-concepts/issues/bulk-ops#copy-work-items) for the selection limit, permissions, and how epics in a mixed selection are handled.
 
 ## Add dependencies
 

--- a/docs/core-concepts/issues/overview.md
+++ b/docs/core-concepts/issues/overview.md
@@ -136,9 +136,9 @@ Custom property values are project-specific, so they can't be carried into anoth
 
 ### Notes and limits
 
-- **Epics** can only be copied into a project that has epics enabled. If the destination project doesn't, the copy is skipped.
+- **Epics** copied into a different project need an Epic type in the destination — that is, the destination project must have [Work item types](/core-concepts/issues/epics) enabled. If it doesn't, Plane refuses the copy with an error instead of demoting the epic to a regular work item. Copying an epic within its own project always works.
 - **Archived work items** are copied as active work items, not as archived ones.
-- Copying multiple work items at once via [bulk operations](/core-concepts/issues/bulk-ops) follows exactly the same rules as copying a single one.
+- Copying multiple work items at once via [bulk operations](/core-concepts/issues/bulk-ops) follows the same field rules as copying a single one. The one difference is the epic case above: in a bulk copy, epics that can't land in the destination are skipped and the rest of the selection still copies.
 
 ## Add dependencies
 


### PR DESCRIPTION
### Description

Updates the **Duplicate work items** section of `core-concepts/issues/overview` to match the copy behavior that shipped recently. The "Copy in same project / Copy in different project" submenu has been replaced by a single **Make a copy** modal with a destination project picker, and the same-project and cross-project paths now follow one consistent spec.

The existing section documented the old submenu and was wrong about the behavior in both directions:

- It said a same-project copy "maintains the same title" — the title now gets a `(Copy)` suffix.
- It described a cross-project copy as only adapting "the destination project's identifier format and default state", while omitting that assignees, labels, modules, cycle, estimate, and every custom property value are cleared. That omission is the part users would actually get burned by.

### What changed

- **One flow, not two** — the `### Copy in same project` / `### Copy in different project` sub-sections are gone, replaced by a description of the single modal with its destination picker defaulting to the current project.
- **A comparison table** covering every field, same project vs. different project. The two cases differ enough that prose would bury it.
- **A one-line rationale** for the cross-project clearing (labels, modules, cycles and estimates are project-scoped), so it reads as a design decision rather than a gap.
- **A tip** on the custom-properties-into-description fallback, since users would otherwise assume the values vanished.
- **Notes and limits** — the epic constraint on cross-project copies, archived items copying as active, and a pointer to bulk operations.
- Mentions the **Duplicate of** backlink relation.

### Not covered here

Two things I deliberately left out, flagging for a reviewer's call:

1. This section carries a **Pro** badge and documents the Pro behavior only. Community projects still use the older prefilled-create-modal flow, which behaves differently — that may warrant its own note.
2. `core-concepts/issues/bulk-ops` doesn't list copy among its bulk operations at all. Now that bulk copy shares the same semantics, that page is arguably missing an entry — linked to from here, but not edited, as it was outside the scope of this change.

### Anchors

`#copy-in-same-project` and `#copy-in-different-project` no longer exist. Nothing in the source tree links to them (grepped), but external inbound links will now land at the page top rather than the section.

### Verification

`pnpm fix:format` runs clean.
