### PR TITLE
docs(developer-docs): fix collapsed info container on one-click deploy

### DIFF
--- a/apps/developer-docs/docs/self-hosting/methods/one-click.md
+++ b/apps/developer-docs/docs/self-hosting/methods/one-click.md
@@ -6,7 +6,9 @@ keywords: plane one-click deploy, cloud deployment, aws plane, digitalocean plan
 
 # One-click deploy
 
-::: infoThis feature is included in our paid plans, but for a limited time, our community users can access it for free.:::
+:::info
+This feature is included in our paid plans, but for a limited time, our community users can access it for free.
+:::
 
 ### Requirements
 


### PR DESCRIPTION
## Summary

The `:::info` container on the one-click deploy page was written on a single line, so VitePress rendered the raw `:::info ... :::` markers as literal text instead of an info callout. Split it onto its own lines.

## Test plan

- `pnpm dev:developer-docs` → visit `/self-hosting/methods/one-click` and confirm the note renders as an info callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hXFZdHcN8R71V17d7pt3W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the paid-plan notice formatting in the self-hosting guide for proper display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->