### PR TITLE
docs(developer-docs): add All releases page for Commercial Edition

### DIFF
--- a/apps/developer-docs/docs/.vitepress/config.mts
+++ b/apps/developer-docs/docs/.vitepress/config.mts
@@ -329,6 +329,7 @@ export default extendConfig(
                 { text: "Overview", link: "/self-hosting/overview" },
                 { text: "Self-hosting 101", link: "/self-hosting/self-hosting-101" },
                 { text: "Plane Editions", link: "/self-hosting/editions-and-versions" },
+                { text: "All releases", link: "/self-hosting/all-releases" },
                 { text: "Plane Architecture", link: "/self-hosting/plane-architecture" },
               ],
             },

--- a/apps/developer-docs/docs/self-hosting/all-releases.md
+++ b/apps/developer-docs/docs/self-hosting/all-releases.md
@@ -1,0 +1,45 @@
+---
+title: All releases - Plane Commercial Edition
+description: Complete list of all Plane Commercial Edition self-hosted releases with release dates, support status, and release notes.
+keywords: plane releases, plane versions, plane commercial edition, plane self-hosted releases, plane changelog, plane version history
+---
+
+# All releases
+
+We recommend self-hosted users run one of the latest releases of Plane Commercial Edition. We regularly ship new features, bug fixes, and security updates. See [Update Plane](/self-hosting/manage/upgrade-plane) for upgrade instructions.
+
+::: tip
+Looking for Community Edition releases? See the [GitHub releases page](https://github.com/makeplane/plane/releases).
+:::
+
+## Plane Commercial Edition 2.x
+
+| Version   | Release date      | Closing down date | Release notes                                                    |
+| :-------- | :---------------- | :---------------- | :--------------------------------------------------------------- |
+| **2.3.0** | January 27, 2026  | April 27, 2026    | [Release notes](https://plane.so/changelog?category=self-hosted) |
+| **2.2.0** | January 19, 2026  | April 19, 2026    | [Release notes](https://plane.so/changelog?category=self-hosted) |
+| **2.1.0** | December 10, 2025 | March 10, 2026    | [Release notes](https://plane.so/changelog?category=self-hosted) |
+| **2.0.0** | December 5, 2025  | March 5, 2026     | [Release notes](https://plane.so/changelog?category=self-hosted) |
+
+## Plane Commercial Edition 1.x
+
+| Version    | Release date       | Closing down date  | Release notes                                                                                                            |
+| :--------- | :----------------- | :----------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| **1.17.0** | November 14, 2025  | February 14, 2026  | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.16.0** | November 5, 2025   | February 5, 2026   | [Release notes](https://plane.so/changelog/release-v-1-16-0-introducing-milestones-and-recurring-cycles)                 |
+| **1.15.0** | October 22, 2025   | January 22, 2026   | [Release notes](https://plane.so/changelog/release-v-1-15-0-embeds-pages-and-integrations-for-connected-cross-team-work) |
+| **1.14.0** | September 2, 2025  | December 2, 2025   | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.13.0** | July 25, 2025      | October 25, 2025   | [Release notes](https://plane.so/changelog/release-v-1-13-0-duplicate-work-items-and-epics-across-projects)              |
+| **1.12.0** | June 30, 2025      | September 30, 2025 | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.11.0** | June 3, 2025       | September 3, 2025  | [Release notes](https://plane.so/changelog/self-hosted-v1_11_0)                                                          |
+| **1.10.0** | May 23, 2025       | August 23, 2025    | [Release notes](https://plane.so/changelog/self-hosted-v1_10_0)                                                          |
+| **1.9.0**  | April 29, 2025     | July 29, 2025      | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.8.0**  | February 2025      | May 2025           | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.7.0**  | January 27, 2025   | April 27, 2025     | [Release notes](https://plane.so/changelog/self-hosted-v1_7_0)                                                           |
+| **1.6.0**  | December 10, 2024  | March 10, 2025     | [Release notes](https://plane.so/changelog/self-hosted-v1_6_0)                                                           |
+| **1.5.0**  | November 25, 2024  | February 25, 2025  | [Release notes](https://plane.so/changelog/self-hosted-v1_5_0)                                                           |
+| **1.4.0**  | October 8, 2024    | January 8, 2025    | [Release notes](https://plane.so/changelog/self-hosted-v1_4_0)                                                           |
+| **1.3.0**  | October 2024       | January 2025       | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.2.0**  | July 1, 2024       | October 1, 2024    | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.1.0**  | October 23, 2024   | January 23, 2025   | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |
+| **1.0.0**  | September 10, 2024 | December 10, 2024  | [Release notes](https://plane.so/changelog?category=self-hosted)                                                         |


### PR DESCRIPTION
Ports [makeplane/developer-docs#213](https://github.com/makeplane/developer-docs/pull/213) into this monorepo.

## What's here

- **`apps/developer-docs/docs/self-hosting/all-releases.md`** (new) — every Plane Commercial Edition self-hosted release with its release date, closing down date, and release notes link, split into 2.x and 1.x tables. Includes a tip pointing Community Edition users at the GitHub releases page.
- **`apps/developer-docs/docs/.vitepress/config.mts`** — sidebar entry under **Self-host Plane**, between *Plane Editions* and *Plane Architecture* (same slot as upstream).

## Deliberately not ported

The upstream PR also bumps `packageManager` from pnpm 10.28.2 to 10.30.1 in the app's `package.json`. That change belongs to the standalone repo — this workspace pins **pnpm 11.8.0** at the root and apps don't carry their own `packageManager` field.

## Worth a look before merging

The release table ends at **2.3.0 (January 27, 2026)**, which is what the upstream PR contains. If newer Commercial Edition releases have shipped since, they should be added — I didn't invent entries.

## Verification

- `pnpm check:format` — clean
- `pnpm --filter developer-docs check:types` — clean
- `pnpm --filter developer-docs build` — succeeds, no dead links (`/self-hosting/manage/upgrade-plane` resolves)

Draft while makeplane/developer-docs#213 is still under review.

https://claude.ai/code/session_019kCVtLs1Yho8dzcuzV4Hrn