### PR TITLE
fix: bump vulnerable transitive deps to resolve dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,11 +44,11 @@ overrides:
   rollup: 4.59.0
   lodash-es: 4.18.1
   esbuild: 0.25.0
-  dompurify: 3.4.11
+  dompurify: 3.4.13
   vite: 6.4.3
-  postcss: 8.5.15
+  postcss: 8.5.26
   uuid: 11.1.1
-  js-yaml: 3.15.0
+  js-yaml: 3.15.1
 
 importers:
 
@@ -75,7 +75,7 @@ importers:
         version: 25.9.5
       '@voidzero-dev/vitepress-theme':
         specifier: 'catalog:'
-        version: 4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
+        version: 4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
       mermaid:
         specifier: 'catalog:'
         version: 11.16.1
@@ -84,16 +84,16 @@ importers:
         version: 6.0.3
       vitepress:
         specifier: 'catalog:'
-        version: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3)
+        version: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3)
       vitepress-plugin-llms:
         specifier: 'catalog:'
         version: 1.13.1
       vitepress-plugin-mermaid:
         specifier: 'catalog:'
-        version: 2.0.17(mermaid@11.16.1)(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))
+        version: 2.0.17(mermaid@11.16.1)(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))
       vitepress-plugin-tabs:
         specifier: 'catalog:'
-        version: 0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
+        version: 0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
       vue:
         specifier: 'catalog:'
         version: 3.5.41(typescript@6.0.3)
@@ -109,19 +109,19 @@ importers:
         version: 25.9.5
       '@voidzero-dev/vitepress-theme':
         specifier: 'catalog:'
-        version: 4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
+        version: 4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitepress:
         specifier: 'catalog:'
-        version: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3)
+        version: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3)
       vitepress-plugin-llms:
         specifier: 'catalog:'
         version: 1.13.1
       vitepress-plugin-tabs:
         specifier: 'catalog:'
-        version: 0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
+        version: 0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
       vue:
         specifier: 'catalog:'
         version: 3.5.41(typescript@6.0.3)
@@ -130,7 +130,7 @@ importers:
     dependencies:
       '@voidzero-dev/vitepress-theme':
         specifier: 'catalog:'
-        version: 4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
+        version: 4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
       lucide-vue-next:
         specifier: 'catalog:'
         version: 0.577.0(vue@3.5.41(typescript@6.0.3))
@@ -139,7 +139,7 @@ importers:
         version: 1.1.0
       vitepress-plugin-tabs:
         specifier: 'catalog:'
-        version: 0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
+        version: 0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -149,7 +149,7 @@ importers:
         version: 6.0.3
       vitepress:
         specifier: 'catalog:'
-        version: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3)
+        version: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3)
       vue:
         specifier: 'catalog:'
         version: 3.5.41(typescript@6.0.3)
@@ -1099,9 +1099,9 @@ packages:
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1339,8 +1339,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1468,8 +1468,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   katex@0.16.47:
@@ -1563,8 +1563,8 @@ packages:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -1755,8 +1755,8 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-bytes@7.1.0:
@@ -2001,7 +2001,7 @@ packages:
     peerDependencies:
       markdown-it-mathjax3: ^4
       oxc-minify: '*'
-      postcss: 8.5.15
+      postcss: 8.5.26
     peerDependenciesMeta:
       markdown-it-mathjax3:
         optional: true
@@ -2679,7 +2679,7 @@ snapshots:
       vite: 6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)
       vue: 3.5.41(typescript@6.0.3)
 
-  '@voidzero-dev/vitepress-theme@4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))':
+  '@voidzero-dev/vitepress-theme@4.8.4(focus-trap@7.8.0)(vite@6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@docsearch/css': 4.6.2
       '@docsearch/js': 4.6.2
@@ -2696,7 +2696,7 @@ snapshots:
       minisearch: 7.2.0
       reka-ui: 2.9.6(vue@3.5.41(typescript@6.0.3))
       tailwindcss: 4.2.1
-      vitepress: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3)
+      vitepress: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3)
       vue: 3.5.41(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -2736,7 +2736,7 @@ snapshots:
       '@vue/shared': 3.5.41
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.41':
@@ -2824,7 +2824,7 @@ snapshots:
 
   birpc@2.9.0: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3074,7 +3074,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.11:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3156,7 +3156,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -3203,7 +3203,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -3269,7 +3269,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -3291,7 +3291,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -3379,7 +3379,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.11
+      dompurify: 3.4.13
       es-toolkit: 1.50.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -3535,7 +3535,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minisearch@7.2.0: {}
 
@@ -3604,7 +3604,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -3860,7 +3860,7 @@ snapshots:
       esbuild: 0.25.0
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.15
+      postcss: 8.5.26
       rollup: 4.59.0
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -3888,19 +3888,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress-plugin-mermaid@2.0.17(mermaid@11.16.1)(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3)):
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.16.1)(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3)):
     dependencies:
       mermaid: 11.16.1
-      vitepress: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3)
+      vitepress: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3)
     optionalDependencies:
       '@mermaid-js/mermaid-mindmap': 9.3.0
 
-  vitepress-plugin-tabs@0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3)):
+  vitepress-plugin-tabs@0.8.0(vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3)):
     dependencies:
-      vitepress: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3)
+      vitepress: 2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3)
       vue: 3.5.41(typescript@6.0.3)
 
-  vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.15)(typescript@6.0.3):
+  vitepress@2.0.0-alpha.16(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)(postcss@8.5.26)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 4.6.2
       '@docsearch/js': 4.6.2
@@ -3922,7 +3922,7 @@ snapshots:
       vite: 6.4.3(@types/node@25.9.5)(jiti@2.6.1)(lightningcss@1.31.1)
       vue: 3.5.41(typescript@6.0.3)
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
     transitivePeerDependencies:
       - '@types/node'
       - async-validator

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,11 +28,11 @@ overrides:
   rollup: 4.59.0
   lodash-es: 4.18.1
   esbuild: 0.25.0
-  dompurify: 3.4.11
+  dompurify: 3.4.13
   vite: 6.4.3
-  postcss: 8.5.15
+  postcss: 8.5.26
   uuid: 11.1.1
-  js-yaml: 3.15.0
+  js-yaml: 3.15.1
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
Closes all 9 open Dependabot alerts, every one of them on `pnpm-lock.yaml`.

## What changed

Three of the five packages were held at vulnerable versions by the `overrides:` block in `pnpm-workspace.yaml`, so the fix is to raise the pins — same pattern as bb7fdf7:

| Package | Before | After | Alerts |
| --- | --- | --- | --- |
| `dompurify` | 3.4.11 | 3.4.13 | #78 low, #79 medium |
| `postcss` | 8.5.15 | 8.5.26 | #71 high, #76 medium |
| `js-yaml` | 3.15.0 | 3.15.1 | #73 high |

The other two had no override and only needed the lockfile refreshed — their parents' declared ranges already allow the patched versions:

| Package | Before | After | Alerts | Parent range |
| --- | --- | --- | --- | --- |
| `brace-expansion` | 5.0.6 | 5.0.9 | #68, #70, #72 high | minimatch wants `^5.0.5` |
| `linkify-it` | 5.0.1 | 5.0.2 | #69 high | markdown-it wants `^5.0.1` |

## Why no override for the last two

`pnpm` overrides apply tree-wide, and `brace-expansion` 5.x replaced the v1/v2 default export with a named `expand`. Pinning it would break any future consumer still on minimatch 9.x, which does `import expand from 'brace-expansion'`. The lockfile pin is durable on its own here: 5.0.9 and 5.0.2 are the tops of their respective ranges, so re-resolution lands on the patched versions.

Every new version still satisfies its consumer's own declared range (`dompurify ^3.3.3`, `postcss ^8.5.3`, `js-yaml ^3.13.1`) — these are security floors, not compatibility ceilings.

## Verification

- `pnpm check:format`, `pnpm dedupe --check`, `pnpm check:types` (3/3), `pnpm build` (both sites) — all pass
- `pnpm audit` — no known vulnerabilities found
- Each of the five packages resolves to exactly one version in the lockfile, all outside their vulnerable ranges
- Single-copy invariant holds: `vue@3.5.41`, `vitepress@2.0.0-alpha.16`, `@voidzero-dev/vitepress-theme@4.8.4`
- Lockfile's recorded `overrides:` block matches `pnpm-workspace.yaml`, so `--frozen-lockfile` won't fail in CI
- Differential testing found no behavior change: 489/489 frontmatter blocks parse identically (js-yaml), 1,917 autolink matches identical (linkify-it), byte-identical CSS output (postcss), 40k fuzzed glob inputs identical (brace-expansion)

Not covered: a live browser render of the two mermaid pages (`dompurify` is consumed client-side by mermaid). Both dompurify advisories are sanitization hardening, so the risk is low, but it is unverified at runtime.

https://claude.ai/code/session_019kCVtLs1Yho8dzcuzV4Hrn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several underlying dependencies to newer patch versions.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->